### PR TITLE
Add VPN

### DIFF
--- a/dns-server/Dockerfile
+++ b/dns-server/Dockerfile
@@ -9,10 +9,6 @@ RUN apt-get update \
 # Enable IPv4
 RUN sed -i 's/OPTIONS=.*/OPTIONS="-4 -u bind"/' /etc/default/bind9
 
-# Copy configuration files
-COPY named.conf.options /etc/bind/
-COPY named.conf.local /etc/bind/
-COPY db.ftilabs.com /etc/bind/zones/
 
 # Run eternal loop
 RUN /etc/init.d/bind9 start

--- a/dns-server/Dockerfile
+++ b/dns-server/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:bionic
+
+RUN apt-get update \
+  && apt-get install -y \
+  bind9 \
+  bind9utils \
+  bind9-doc
+
+# Enable IPv4
+RUN sed -i 's/OPTIONS=.*/OPTIONS="-4 -u bind"/' /etc/default/bind9
+
+# Copy configuration files
+COPY named.conf.options /etc/bind/
+COPY named.conf.local /etc/bind/
+COPY db.ftilabs.com /etc/bind/zones/
+
+# Run eternal loop
+RUN /etc/init.d/bind9 start
+CMD ["/bin/bash", "-c", "while :; do sleep 10; done"]

--- a/dns-server/db.ftilabs.com
+++ b/dns-server/db.ftilabs.com
@@ -18,4 +18,5 @@ host3.ftilabs.com.        IN      A      172.24.118.15
 host4.ftilabs.com.        IN      A      172.24.118.16
 ftp.ftilabs.com.          IN      A      172.11.15.53
 http.ftilabs.com.         IN      A      172.11.15.61
-https.ftilabs.com.        IN      A      172.11.15.71 
+https.ftilabs.com.        IN      A      172.11.15.71
+vpn.ftilabs.com.          IN      A      172.11.15.115

--- a/dns-server/db.ftilabs.com
+++ b/dns-server/db.ftilabs.com
@@ -1,0 +1,21 @@
+$TTL    604800
+@       IN      SOA     ns1.ftilabs.com. root.ftilabs.com. (
+                  3       ; Serial
+             604800     ; Refresh
+              86400     ; Retry
+            2419200     ; Expire
+             604800 )   ; Negative Cache TTL
+;
+; name servers - NS records
+     IN      NS      ns1.ftilabs.com.
+
+; name servers - A records
+ns1.ftilabs.com.          IN      A      172.11.15.110
+
+host1.ftilabs.com.        IN      A      172.16.238.10
+host2.ftilabs.com.        IN      A      172.16.238.30
+host3.ftilabs.com.        IN      A      172.24.118.15
+host4.ftilabs.com.        IN      A      172.24.118.16
+ftp.ftilabs.com.          IN      A      172.11.15.53
+http.ftilabs.com.         IN      A      172.11.15.61
+https.ftilabs.com.        IN      A      172.11.15.71 

--- a/dns-server/named.conf.local
+++ b/dns-server/named.conf.local
@@ -1,0 +1,4 @@
+zone "ftilabs.com" {
+    type master;
+    file "/etc/bind/zones/db.ftilabs.com";
+};

--- a/dns-server/named.conf.options
+++ b/dns-server/named.conf.options
@@ -1,0 +1,11 @@
+options {
+    directory "/var/cache/bind";
+
+    recursion yes;
+    listen-on { any; };
+
+    forwarders {
+            8.8.8.8;
+            8.8.4.4;
+    };
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,12 +220,17 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
 
+# DNS server configuraition
   dns-server:
     depends_on:
       - corp_gateway
     build: dns-server
     container_name: DNS
     restart: on-failure
+    volumes:
+      - ./dns-server/named.conf.options:/etc/bind/named.conf.options
+      - ./dns-server/named.conf.local:/etc/bind/named.conf.local
+      - ./dns-server/db.ftilabs.com:/etc/bind/zones/db.ftilabs.com
     networks:
       default:
       gw_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,6 +236,29 @@ services:
       gw_net:
         ipv4_address: 172.11.15.110
 
+
+# VPN(IPsec) server configuration 
+  vpn-server:
+    depends_on:
+      - dns-server
+    image: hwdsl2/ipsec-vpn-server
+    container_name: VPN
+    dns: 172.11.15.110
+    ports:
+      - '500:500'
+      - '4500:4500'
+    privileged: true
+    restart: on-failure
+    volumes:
+      - /lib/modules/:/lib/modules:ro
+    env_file:
+      - vpn.env
+    networks:
+      vpn_net:
+        ipv4_address: 192.168.0.55
+      gw_net:
+        ipv4_address: 172.11.15.115
+
 networks:
     icorp1_net:
         driver: macvlan
@@ -263,4 +286,9 @@ networks:
             config:
                 - subnet: 10.10.15.0/24
 
-
+    vpn_net:
+        driver: macvlan
+        ipam:
+            driver: default
+            config:
+                - subnet: 192.168.0.0/24

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
   client_pc1:
     container_name: client_pc1
     build: pc
+    dns: 172.11.15.110
     #ports:
         #- "8022:22"
     command: >
@@ -94,6 +95,7 @@ services:
   client_pc2:
     container_name: client_pc2
     build: pc
+    dns: 172.11.15.110
     command: >
         sh -c 'sh /root/configure.sh 172.16.238.1 172.16.238.22 &&
         sh /root/client_emulator.sh ftpp 172.11.15.53 &&
@@ -111,6 +113,7 @@ services:
   client_pc3:
     container_name: client_pc3
     build: pc
+    dns: 172.11.15.110
     command: >
         sh -c 'sh /root/configure.sh 172.24.118.1 172.24.118.22 &&
         sh /root/client_emulator.sh ftpg 172.11.15.53 &&
@@ -125,6 +128,7 @@ services:
   client_pc4:
     container_name: client_pc4
     build: pc
+    dns: 172.11.15.110
     command: >
         sh -c "sh /root/configure.sh 172.24.118.1 172.24.118.22 &&
         sh /root/client_emulator.sh wp 172.11.15.71 &&
@@ -139,6 +143,7 @@ services:
 # Backend services
   ftp_server:
     container_name: ftp_server
+    dns: 172.11.15.110
     image: delfer/alpine-ftp-server
     ports:
         - "21:21"
@@ -156,6 +161,7 @@ services:
   http_server:
     container_name: http_server
     image: httpd:2.4
+    dns: 172.11.15.110
     volumes:
       - ./site_data/kpi.ua/:/usr/local/apache2/htdocs/
     networks:
@@ -167,6 +173,7 @@ services:
 
   https-portal:
     build: portal_patched
+    dns: 172.11.15.110
     ports:
       - '80:80'
       - '443:443'
@@ -213,6 +220,16 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
 
+  dns-server:
+    depends_on:
+      - corp_gateway
+    build: dns-server
+    container_name: DNS
+    restart: on-failure
+    networks:
+      default:
+      gw_net:
+        ipv4_address: 172.11.15.110
 
 networks:
     icorp1_net:

--- a/pc/Dockerfile
+++ b/pc/Dockerfile
@@ -1,8 +1,10 @@
 FROM ubuntu
 RUN apt-get update
-RUN DEBIAN_FRONTEND="noninteractive" apt install inetutils-ping iptables iproute2 net-tools curl busybox ftp ssh tcpdump nmap arping macchanger libtext-lorem-perl dsniff -y
+RUN DEBIAN_FRONTEND="noninteractive" apt install inetutils-ping iptables iproute2 net-tools curl busybox ftp ssh tcpdump nmap arping macchanger libtext-lorem-perl dsniff strongswan xl2tpd -y
 COPY client_emulator.sh /root/client_emulator.sh
 COPY xmlsample /root/xmlsample
 COPY configure.sh /root/configure.sh
+COPY vpn.sh /root/vpn.sh
+COPY stop.vpn.sh /root/stop.vpn.sh
 RUN chmod +x /root/*
 

--- a/pc/stop.vpn.sh
+++ b/pc/stop.vpn.sh
@@ -1,0 +1,2 @@
+echo "d myvpn" > /var/run/xl2tpd/l2tp-control
+ipsec down myvpn

--- a/pc/vpn.sh
+++ b/pc/vpn.sh
@@ -1,0 +1,66 @@
+apt update
+apt install -y strongswan xl2tpd
+VPN_SERVER_IP="172.11.15.115"
+VPN_IPSEC_PSK="your_ipsec_pre_shared_key"
+VPN_USER="ftilabs"
+VPN_PASSWORD="ftibest"
+
+cat > /etc/ipsec.conf <<EOF
+
+# ipsec.conf - strongSwan IPsec configuration file
+
+conn myvpn
+  auto=add
+  keyexchange=ikev1
+  authby=secret
+  type=transport
+  left=%defaultroute
+  leftprotoport=17/1701
+  rightprotoport=17/1701
+  right=$VPN_SERVER_IP
+  ike=aes128-sha1-modp2048
+  esp=aes128-sha1
+EOF
+
+cat > /etc/ipsec.secrets <<EOF
+: PSK "$VPN_IPSEC_PSK"
+EOF
+chmod 600 /etc/ipsec.secrets
+cat > /etc/xl2tpd/xl2tpd.conf <<EOF
+[lac myvpn]
+lns = $VPN_SERVER_IP
+ppp debug = yes
+pppoptfile = /etc/ppp/options.l2tpd.client
+length bit = yes
+EOF
+
+cat > /etc/ppp/options.l2tpd.client <<EOF
+ipcp-accept-local
+ipcp-accept-remote
+refuse-eap
+require-chap
+noccp
+noauth
+mtu 1280
+mru 1280
+noipdefault
+defaultroute
+usepeerdns
+connect-delay 5000
+name "$VPN_USER"
+password "$VPN_PASSWORD"
+EOF
+
+chmod 600 /etc/ppp/options.l2tpd.client
+
+mkdir -p /var/run/xl2tpd
+touch /var/run/xl2tpd/l2tp-control
+ipsec restart
+service xl2tpd restart
+ipsec up myvpn
+sleep 8
+echo "c myvpn" > /var/run/xl2tpd/l2tp-control
+sleep 8
+ifconfig
+
+ip route add 172.11.15.110 via $(ip address show dev ppp0 | grep -Po '(?<=peer )(\b([0-9]{1,3}\.){3}[0-9]{1,3}\b)') dev ppp0

--- a/start_lab.sh
+++ b/start_lab.sh
@@ -14,6 +14,6 @@ cd ..
 sudo chown $USER:$USER . -R
 
 docker-compose up -d --build
-
+docker exec DNS /etc/init.d/bind9 start
 echo ''
 echo -e "\e[33mCURRENT INFRASTRUCTURE VERSION: \e[93m`git tag|tail -1`\e[0m"

--- a/stop_lab.sh
+++ b/stop_lab.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose down
+docker-compose down --volumes --remove-orphans
 
 echo ''
 echo -e "\e[33mCURRENT INFRASTRUCTURE VERSION: \e[93m`git tag|tail -1`\e[0m"

--- a/vpn.env
+++ b/vpn.env
@@ -1,0 +1,6 @@
+VPN_IPSEC_PSK=your_ipsec_pre_shared_key
+VPN_USER=ftilabs
+VPN_PASSWORD=ftibest
+VPN_DNS_NAME=vpn.ftilabs.com
+VPN_DNS_SRV1=1.1.1.1
+VPN_DNS_SRV2=1.0.0.1


### PR DESCRIPTION
In scope of this PR I added VPN server, based on hwdsl2/ipsec-vpn-server image. VPN configs a stored in vpn.env and DNS modified to be able resolve vpn.ftilabs.com. Also I added 2 scripts, which copies to image of Client_pc. First one is "vpn.sh", which installs strongswan and xl2tpd packages, configures ipsec connection and starts it. All the traffic is routed to VPN server 172.11.15.110. Connection was checked and tested through comprehension of tcpdump's with and without VPN connection
![image](https://user-images.githubusercontent.com/37014669/158073914-54dc0f42-6854-4a98-8465-e826354e060a.png)
![image](https://user-images.githubusercontent.com/37014669/158074033-cabed4eb-76b6-4ea8-b9e9-b5f1cde4db93.png)

First image - VPN turned on. Second - VPN turned off. Notice src and destination addresses on the both picrutes